### PR TITLE
Fade window when history is empty.

### DIFF
--- a/PxKeystrokesUi/Settings.Designer.cs
+++ b/PxKeystrokesUi/Settings.Designer.cs
@@ -84,6 +84,7 @@
             this.slider_bi_size = new System.Windows.Forms.TrackBar();
             this.button_exit = new System.Windows.Forms.Button();
             this.button_close = new System.Windows.Forms.Button();
+            this.cb_hideWindow = new System.Windows.Forms.CheckBox();
             ((System.ComponentModel.ISupportInitialize)(this.slider_opacity)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.slider_fontsize)).BeginInit();
             this.groupBox_text_alignment.SuspendLayout();
@@ -287,6 +288,7 @@
             // 
             // gb_text
             // 
+            this.gb_text.Controls.Add(this.cb_hideWindow);
             this.gb_text.Controls.Add(this.cb_backspace);
             this.gb_text.Controls.Add(this.label_timeout_display);
             this.gb_text.Controls.Add(this.cb_enableHistoryTimeout);
@@ -310,7 +312,7 @@
             // cb_backspace
             // 
             this.cb_backspace.AutoSize = true;
-            this.cb_backspace.Location = new System.Drawing.Point(6, 216);
+            this.cb_backspace.Location = new System.Drawing.Point(6, 232);
             this.cb_backspace.Name = "cb_backspace";
             this.cb_backspace.Size = new System.Drawing.Size(153, 17);
             this.cb_backspace.TabIndex = 45;
@@ -695,6 +697,17 @@
             this.button_close.UseVisualStyleBackColor = true;
             this.button_close.Click += new System.EventHandler(this.button_close_Click);
             // 
+            // cb_hideWindow
+            // 
+            this.cb_hideWindow.AutoSize = true;
+            this.cb_hideWindow.Location = new System.Drawing.Point(6, 209);
+            this.cb_hideWindow.Name = "cb_hideWindow";
+            this.cb_hideWindow.Size = new System.Drawing.Size(147, 17);
+            this.cb_hideWindow.TabIndex = 46;
+            this.cb_hideWindow.Text = "Hide window when empty";
+            this.cb_hideWindow.UseVisualStyleBackColor = true;
+            this.cb_hideWindow.CheckedChanged += new System.EventHandler(this.cb_hideWindow_CheckedChanged);
+            // 
             // Settings
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -804,5 +817,6 @@
         private System.Windows.Forms.CheckBox cb_bi_history;
         private System.Windows.Forms.Button button_exit;
         private System.Windows.Forms.Button button_close;
+        private System.Windows.Forms.CheckBox cb_hideWindow;
     }
 }

--- a/PxKeystrokesUi/Settings.cs
+++ b/PxKeystrokesUi/Settings.cs
@@ -264,6 +264,7 @@ namespace PxKeystrokesUi
         {
             cb_cursorindicator.Checked = settings.EnableCursorIndicator;
             cb_enableHistoryTimeout.Checked = settings.EnableHistoryTimeout;
+            cb_hideWindow.Checked = settings.EnableWindowFade;
             cb_bi_history.Checked = settings.AddButtonEventsToHistory;
             cb_backspace.Checked = settings.BackspaceDeletesText;
         }
@@ -307,12 +308,9 @@ namespace PxKeystrokesUi
             this.Close();
         }
 
-
-
-
-
-
-
-
+        private void cb_hideWindow_CheckedChanged(object sender, EventArgs e)
+        {
+            settings.EnableWindowFade = cb_hideWindow.Checked;
+        }
     }
 }

--- a/PxKeystrokesUi/SettingsStore.cs
+++ b/PxKeystrokesUi/SettingsStore.cs
@@ -254,6 +254,14 @@ namespace PxKeystrokesUi
             set { enableHistoryTimeout = value; OnSettingChanged("EnableHistoryTimeout"); }
         }
 
+        private bool enableWindowFade;
+        public bool EnableWindowFadeDefault = true;
+        public bool EnableWindowFade
+        {
+            get { return enableWindowFade; }
+            set { enableWindowFade = value; OnSettingChanged("EnableWindowFade"); }
+        }
+
         private bool enableCursorIndicator;
         public bool EnableCursorIndicatorDefault = true;
         public bool EnableCursorIndicator


### PR DESCRIPTION
Added functionality to fade the window out when the history is empty, per #12 . The window also fades in when the user starts typing again. I added a checkbox to the settings window to turn this functionality on and off. The window fade out timer is the history fadeout timer (So the window fades out when the last history does).