### PR TITLE
Fix Cursor Multi-Screen Offset Issue

### DIFF
--- a/PxKeystrokesUi/MouseRawEvent.cs
+++ b/PxKeystrokesUi/MouseRawEvent.cs
@@ -59,7 +59,12 @@ namespace PxKeystrokesUi
 
         public Point Position
         {
-            get { return new Point(Msllhookstruct.pt.X, Msllhookstruct.pt.Y); }
+            get {
+                NativeMethodsMouse.POINT screenCoords;
+                screenCoords.X = screenCoords.Y = 0;
+                NativeMethodsMouse.GetCursorPos(ref screenCoords);
+                return new Point(screenCoords.X, screenCoords.Y); 
+            }
         }
 
         public void ParseWparam(UIntPtr wParam)

--- a/PxKeystrokesUi/NativeMethodsMouse.cs
+++ b/PxKeystrokesUi/NativeMethodsMouse.cs
@@ -44,6 +44,9 @@ namespace PxKeystrokesUi
         [DllImport("user32.dll", CharSet = CharSet.Auto, ExactSpelling = true)]
         public static extern int GetDoubleClickTime();
 
+        [DllImport("user32.dll", CharSet = CharSet.Auto, SetLastError = true)]
+        public static extern bool GetCursorPos(ref POINT lpPoint);
+
         public const int WH_MOUSE_LL = 14;
         public const int HC_ACTION = 0; // The wParam and lParam parameters contain information about a mouse message.
 


### PR DESCRIPTION
The existing mouse hook is getting cursor position information from the [MSLLHOOKSTRUCT ](https://docs.microsoft.com/en-us/windows/win32/api/winuser/ns-winuser-msllhookstruct) Windows API. This is described as "per-monitor-aware" coordinates. It does not seem to play nicely with 4k/hi-DPI/multiple monitors.

This PR introduces an alternative call into Windows API to [`GetCursorPos`](https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-getcursorpos). It appears to work much better in the above circumstances (at least for me).

I was experiencing the same bugs reported in #28, #29, #39, and #42. 

This patch fixes the above issue for my system configuration:

2018 Dell XPS15 (9570) w/ 4k internal screen and external 4k monitor (dual monitor setup)

