### PR TITLE
Add build instructions and disable signing

### DIFF
--- a/DEVELOP.md
+++ b/DEVELOP.md
@@ -1,3 +1,7 @@
+# Building
+
+To build this program, you must install Visual Studio. You can then simply import the source code from this repository and open the included .sln project file.
+
 # PxKeystrokesForScreencasts
 (aka PxKS)
 

--- a/PxKeystrokesUi/PxKeystrokesUi.csproj
+++ b/PxKeystrokesUi/PxKeystrokesUi.csproj
@@ -57,7 +57,7 @@
     <ApplicationIcon>app.ico</ApplicationIcon>
   </PropertyGroup>
   <PropertyGroup>
-    <SignAssembly>true</SignAssembly>
+    <SignAssembly>false</SignAssembly>
   </PropertyGroup>
   <PropertyGroup>
     <AssemblyOriginatorKeyFile>phaiax.key.pfx</AssemblyOriginatorKeyFile>


### PR DESCRIPTION
Added simple build instructions and disabled signing. The key file (phaiax.key.pfx) is unavailable and causes build issues when trying to build the application.

If the key issue is due to my setup, please send me instructions on how to locally fix the key problem (do I need to generate my own signing key?)